### PR TITLE
Use latest beta release of helm chart

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,7 @@ resource "helm_release" "operator" {
   name       = "terraform-operator"
   repository = "https://helm.releases.hashicorp.com"
   chart      = "terraform-cloud-operator"
-  version    = "2.0.0-beta7"
+  version    = "2.0.0-beta8"
 
   namespace        = kubernetes_namespace.tfc-operator-system.metadata[0].name
   create_namespace = true


### PR DESCRIPTION
This is so that practitioners will be using the latest version of the helm chart beta by default, which has significant bug fixes and enhancements included within it: https://github.com/hashicorp/terraform-cloud-operator/releases/tag/v2.0.0-beta8